### PR TITLE
RFC: Duck typing and consistent return types for all solvers.

### DIFF
--- a/test/tests.jl
+++ b/test/tests.jl
@@ -19,19 +19,19 @@ for solver in solvers
     # dy
     # -- = 6 ==> y = 6t
     # dt
-    t,y=solver((t,y)->6, [0:.1:1], [0.])
+    t,y=solver((t,y)->6, 0., [0:.1:1])
     @test maximum(abs(y-6t)) < tol
 
     # dy
     # -- = 2t ==> y = t.^2
     # dt
-    t,y=solver((t,y)->2t, [0:.001:1], [0.])
+    t,y=solver((t,y)->2t, 0., [0:.001:1])
     @test maximum(abs(y-t.^2)) < tol
     
     # dy
     # -- = y ==> y = y0*e.^t
     # dt
-    t,y=solver((t,y)->y, [0:.001:1], [1.])
+    t,y=solver((t,y)->y, 1., [0:.001:1])
     @test maximum(abs(y-e.^t)) < tol
 
     # dv       dw
@@ -39,8 +39,9 @@ for solver in solvers
     # dt       dt
     #
     # y = [v, w]
-    t,y=solver((t,y)->[-y[2], y[1]], [0:.001:2*pi], [1., 2.])
-    @test maximum(abs(y-[cos(t)-2*sin(t) 2*cos(t)+sin(t)])) < tol
+    t,y=solver((t,y)->[-y[2], y[1]], [1., 2.], [0:.001:2*pi])
+    ys = hcat(y...).'   # convert Vector{Vector{Float}} to Matrix{Float}
+    @test maximum(abs(ys-[cos(t)-2*sin(t) 2*cos(t)+sin(t)])) < tol
 end
 
 println("All looks OK")


### PR DESCRIPTION
As discussed in #7 we want to allow more general types for `y0`. This PR removes the type declarations for the function arguments `F`, `y0` and `tspan`. All solvers return two arrays of values `Vector{eltype(tspan)}` and `Vector{typeof(y0)}`. **This will most certainly break existing codes.**

There is one issue I would like to mention: the present version of `oderosenbrock` will IMO only work with `y0::AbstractVector` or `y0::Number` (mainly due to `jacobi`).

Here is a simple example for the new possibilities:

```
using ODE
H = [[0. 1.]; [1. 0.]];
rho0 = zeros(2,2);
rho0[1,1]=1.;
t,y = ode23((t,y)->(-im*H*y + im*y*H), [0., 2pi], complex(rho0));

using Winston
plot(t,  Float64[real(R[1,1]) for R in y], t, cos(t).^2, "bo")
oplot(t, Float64[real(R[2,2]) for R in y], "--", t, sin(t).^2, "rs")
```

This should work with all solvers except `oderosenbrock`.
