### PR TITLE
RFC: solver ode23s for stiff problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Various basic Ordinary Differential Equation solvers implemented in Julia.
 Pull requests are always highly welcome to fix bugs, add solvers, or anything else!
 
 # API discussions
-There are currently discussions about how the Julian API for ODE solvers should look like, and the current documentation is more like a wishlist than a documentation. The API has changed considerably since the 0.1 release, so be carefull when you upgrade after the next version is released. 
+There are currently discussions about how the Julian API for ODE solvers should look like, and the current documentation is more like a wishlist than a documentation. The API has changed considerably since the 0.1 release, so be carefull when you upgrade after the next version is released.
 # Current status of the project
 
 The current release, v0.1, contains the basic functionality that was moved here when the package was originally moved here from Base. Although quite poorly tested, at least some of the functionality, especially the `ode45` solver, is quite reliable. However, that version is almost entirely undocumented, and will probably stay that way.
@@ -18,10 +18,12 @@ Currently, `ODE` exports the following adaptive solvers:
 * `ode45`: 4th order adaptive solver with 5th order error control, using the Dormand Prince coefficients. Fehlberg and Cash-Karp coefficients are also available.
 * `ode78`: 7th order adaptive solver with 8th order error control, using the Fehlberg coefficients
 
+* `ode23s`: 2nd/3rd order adaptive solver for stiff problems, using a modified Rosenbrock triple
+
 all of which have the following basic API:
 
     tout, yout = odeXX(F, y0, tspan)
-    
+
 to solve the explicit ODE defined by dy/dt = F(t,y). A few other solvers are also exported, see the source code for details.
 
 # Need something long-term reliable right now?

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,8 @@ solvers = [
     ODE.ode45_fb,
     ODE.ode45_ck,
 
+    ODE.ode23s,
+
     ODE.ode4ms,
     ODE.ode4s_s,
     ODE.ode4s_kr,
@@ -30,7 +32,7 @@ for solver in solvers
     # dt
     t,y=solver((t,y)->2t, 0., [0:.001:1])
     @test maximum(abs(y-t.^2)) < tol
-    
+
     # dy
     # -- = y ==> y = y0*e.^t
     # dt


### PR DESCRIPTION
The implementation is based on the "modified Rosenbrock triple" described in

> L.F. Shampine and M.W. Reichelt: "The MATLAB ODE Suite," SIAM Journal on Scientific Computing, Vol. 18, 1997, pp. 1–22

which is also the basis for MATLAB's `ode23s`. In addition to the usual keywords, the solver accepts a keyword `jacobian`, which can be used to supply a function giving the Jacobian of the RHS. Otherwise a (very crude) finite-difference method is used (pulled out from `oderosenbrock`).

A simple example is:

```
# Example: van der Pol oscillator
import ODE: ode23s

function vdP(t,y,mu)
    dy = zeros(y)

    dy[1] = y[2]
    dy[2] = -y[1] + mu*(1 - y[1]^2)*y[2]

    return dy
end

function jac_vdP(t,y,mu)
    dFdy = zeros(length(y), length(y))

    dFdy[1,1] = 0.
    dFdy[1,2] = 1.

    dFdy[2,1] = -1. - mu*2*y[1]*y[2]
    dFdy[2,2] = mu*(1 - y[1]^2)

    return dFdy
end

tout, yout = ode23s((t,y)->vdP(t,y,1000), [2.,0.], [0., 3000.], jacobian=(t,y)->jac_vdP(t,y,1000), reltol=1e-3, abstol=1e-6)
```

Yielding for the first component of `yout`
![ode23s-vdp1000](https://cloud.githubusercontent.com/assets/6170781/4168694/96fff46c-351f-11e4-98bb-9545faa66977.png)

This PR should also "fix" #1.
