### PR TITLE
Fix ode4 argument order in comments

### DIFF
--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -366,7 +366,7 @@ const ode45 = ode45_dp
 #ODE4  Solve non-stiff differential equations, fourth order
 #   fixed-step Runge-Kutta method.
 #
-#   [T,X] = ODE4(ODEFUN, TSPAN, X0) with TSPAN = [T0:H:TFINAL]
+#   [T,X] = ODE4(ODEFUN, X0, TSPAN) with TSPAN = [T0:H:TFINAL]
 #   integrates the system of differential equations x' = f(t,x) from time
 #   T0 to TFINAL in steps of H with initial conditions X0. Function
 #   ODEFUN(T,X) must return a column vector corresponding to f(t,x). Each


### PR DESCRIPTION
If you're like me, you spend waaay too long wondering why the simple RK4 solver isn't working instead of actually checking the function itself. The comments above the function had the argument order wrong - this tiny commit fixes that.
