### PR TITLE
Fixed to allow using matrices as scalar like entity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.3
     - release
     - nightly
 git:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.4
 Polynomials
 Compat 0.4.1

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -91,7 +91,7 @@ end
 
 # isoutofdomain takes the state and returns true if state is outside
 # of the allowed domain.  Used in adaptive step-control.
-isoutofdomain(x) = isnan(x)
+isoutofdomain(x) = any(isnan(x))
 
 function make_consistent_types(fn, y0, tspan, btab::Tableau)
     # There are a few types involved in a call to a ODE solver which


### PR DESCRIPTION
Fixes #86 

Note, this drops Julia 0.3 compatibility due to a bug in its `norm` function (shows up in `hinit`).
