### PR TITLE
Update the oldest release testing to v0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
     - osx
     - linux
 julia:
-    - 0.3
+    - 0.4
     - release
     - nightly
 git:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.4
 Polynomials
-Compat 0.4.1
+Compat 0.9


### PR DESCRIPTION
Now it should be v0.4, v0.5, and v0.6 instead of v0.3 v0.5 v0.6. We are already not compatible for v0.3