### PR TITLE
add common interface bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.4
     - release
     - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 Polynomials
 Compat 0.9
 DiffEqBase

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 Polynomials
 Compat 0.9
+DiffEqBase

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -22,7 +22,7 @@ export ode23s
 export ode4s
 
 # Common Interface
-export ODEJLAlgorithm
+export ODEjlAlgorithm
 
 ## complete function export list: see runtests.jl
 

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -420,7 +420,7 @@ const s4_coefficients = (0.5,
 ode4s_s(F, x0, tspan; jacobian=nothing) = oderosenbrock(F, x0, tspan, s4_coefficients...; jacobian=jacobian)
 
 # Use Shampine coefficients by default (matching Numerical Recipes)
-const ode4s = ode4s_s
+ode4s(F, x0, tspan; jacobian=nothing) = ode4s_s(F, x0, tspan; jacobian=nothing)
 
 const ms_coefficients4 = [ 1      0      0     0
                           -1/2    3/2    0     0

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -9,6 +9,8 @@ using DiffEqBase
 
 import DiffEqBase: solve
 
+include("algorithm_types.jl")
+
 ## minimal function export list
 # adaptive non-stiff:
 export ode23, ode45, ode78

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -21,6 +21,9 @@ export ode23s
 # non-adaptive stiff:
 export ode4s
 
+# Common Interface
+export ODEJLAlgorithm
+
 ## complete function export list: see runtests.jl
 
 ###############################################################################

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -157,7 +157,7 @@ include("runge_kutta.jl")
 
 # ODE_MS Fixed-step, fixed-order multi-step numerical method
 #   with Adams-Bashforth-Moulton coefficients
-function ode_ms(F, x0, tspan, order::Integer)
+function ode_ms(F, x0, tspan, order::Integer; kwargs...)
     h = diff(tspan)
     x = Array(typeof(x0), length(tspan))
     x[1] = x0
@@ -194,8 +194,8 @@ function ode_ms(F, x0, tspan, order::Integer)
 end
 
 # Use order 4 by default
-ode4ms(F, x0, tspan) = ode_ms(F, x0, tspan, 4)
-ode5ms(F, x0, tspan) = ODE.ode_ms(F, x0, tspan, 5)
+ode4ms(F, x0, tspan; kwargs...) = ode_ms(F, x0, tspan, 4; kwargs...)
+ode5ms(F, x0, tspan; kwargs...) = ODE.ode_ms(F, x0, tspan, 5; kwargs...)
 
 ###############################################################################
 ## STIFF SOLVERS
@@ -350,7 +350,7 @@ end
 
 #ODEROSENBROCK Solve stiff differential equations, Rosenbrock method
 #   with provided coefficients.
-function oderosenbrock(F, x0, tspan, gamma, a, b, c; jacobian=nothing)
+function oderosenbrock(F, x0, tspan, gamma, a, b, c; jacobian=nothing, kwargs...)
 
     if typeof(jacobian) == Function
         G = jacobian
@@ -403,7 +403,7 @@ const kr4_coefficients = (0.231,
                             6.02015272865   0.1597500684673  0        0
                            -1.856343618677 -8.50538085819   -2.08407513602 0],)
 
-ode4s_kr(F, x0, tspan; jacobian=nothing) = oderosenbrock(F, x0, tspan, kr4_coefficients...; jacobian=jacobian)
+ode4s_kr(F, x0, tspan; jacobian=nothing, kwargs...) = oderosenbrock(F, x0, tspan, kr4_coefficients...; jacobian=jacobian, kwargs...)
 
 # Shampine coefficients
 const s4_coefficients = (0.5,
@@ -417,10 +417,11 @@ const s4_coefficients = (0.5,
                            372/25   12/5    0   0
                           -112/125 -54/125 -2/5 0],)
 
-ode4s_s(F, x0, tspan; jacobian=nothing) = oderosenbrock(F, x0, tspan, s4_coefficients...; jacobian=jacobian)
+ode4s_s(F, x0, tspan; jacobian=nothing, kwargs...) =
+      oderosenbrock(F, x0, tspan, s4_coefficients...; jacobian=jacobian, kwargs...)
 
 # Use Shampine coefficients by default (matching Numerical Recipes)
-ode4s(F, x0, tspan; jacobian=nothing) = ode4s_s(F, x0, tspan; jacobian=nothing)
+ode4s(F, x0, tspan; jacobian=nothing, kwargs...) = ode4s_s(F, x0, tspan; jacobian=nothing, kwargs...)
 
 const ms_coefficients4 = [ 1      0      0     0
                           -1/2    3/2    0     0

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -5,6 +5,9 @@ module ODE
 
 using Polynomials
 using Compat
+using DiffEqBase
+
+import DiffEqBase: solve
 
 ## minimal function export list
 # adaptive non-stiff:
@@ -422,5 +425,8 @@ const ms_coefficients4 = [ 1      0      0     0
                           5/12  -4/3  23/12 0
                           -9/24   37/24 -59/24 55/24]
 
+####### Common Interface Bindings
+
+include("common.jl")
 
 end # module ODE

--- a/src/algorithm_types.jl
+++ b/src/algorithm_types.jl
@@ -1,8 +1,10 @@
-abstract ODEJLAlgorithm <: AbstractODEAlgorithm
-immutable ode23 <: ODEJLAlgorithm end
-immutable ode45 <: ODEJLAlgorithm end
-immutable ode23s <: ODEJLAlgorithm end
-immutable ode78 <: ODEJLAlgorithm end
-immutable ode4 <: ODEJLAlgorithm end
-immutable ode4ms <: ODEJLAlgorithm end
-immutable ode4s <: ODEJLAlgorithm end
+abstract ODEjlAlgorithm <: AbstractODEAlgorithm
+# Making the ODE-solver functions into types lets us dispatch on them.
+#  Used in the DiffEqBase interface.
+immutable ode23 <: ODEjlAlgorithm end
+immutable ode45 <: ODEjlAlgorithm end
+immutable ode23s <: ODEjlAlgorithm end
+immutable ode78 <: ODEjlAlgorithm end
+immutable ode4 <: ODEjlAlgorithm end
+immutable ode4ms <: ODEjlAlgorithm end
+immutable ode4s <: ODEjlAlgorithm end

--- a/src/algorithm_types.jl
+++ b/src/algorithm_types.jl
@@ -1,0 +1,8 @@
+abstract ODEJLAlgorithm <: AbstractODEAlgorithm
+immutable ode23 <: ODEJLAlgorithm end
+immutable ode45 <: ODEJLAlgorithm end
+immutable ode23s <: ODEJLAlgorithm end
+immutable ode78 <: ODEJLAlgorithm end
+immutable ode4 <: ODEJLAlgorithm end
+immutable ode4ms <: ODEJLAlgorithm end
+immutable ode4s <: ODEJLAlgorithm end

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,9 +1,3 @@
-abstract ODEJLAlgorithm <: AbstractODEAlgorithm
-immutable ode23Alg <: ODEJLAlgorithm end
-immutable ode45Alg <: ODEJLAlgorithm end
-immutable ode23sAlg <: ODEJLAlgorithm end
-immutable ode78Alg <: ODEJLAlgorithm end
-
 function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractODEProblem{uType,tType,isinplace,F},
     alg::algType,timeseries=[],ts=[],ks=[];dense=true,save_timeseries=true,
     saveat=tType[],timeseries_errors=true,reltol = 1e-5, abstol = 1e-8,
@@ -44,7 +38,7 @@ function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractOD
         u0 = prob.u0
     end
 
-    if typeof(alg) <: ode23Alg
+    if typeof(alg) <: ode23
         ts,timeseries_tmp = ODE.ode23(f,u0,Ts,
                           norm = norm,
                           abstol=abstol,
@@ -53,7 +47,7 @@ function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractOD
                           minstep=dtmin,
                           initstep=dt,
                           points=points)
-    elseif typeof(alg) <: ode45Alg
+    elseif typeof(alg) <: ode45
         ts,timeseries_tmp = ODE.ode45(f,u0,Ts,
                           norm = norm,
                           abstol=abstol,
@@ -62,7 +56,7 @@ function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractOD
                           minstep=dtmin,
                           initstep=dt,
                           points=points)
-    elseif typeof(alg) <: ode78Alg
+    elseif typeof(alg) <: ode78
         ts,timeseries_tmp = ODE.ode78(f,u0,Ts,
                           norm = norm,
                           abstol=abstol,
@@ -71,8 +65,35 @@ function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractOD
                           minstep=dtmin,
                           initstep=dt,
                           points=points)
-    elseif typeof(alg) <: ode23sAlg
+    elseif typeof(alg) <: ode23s
         ts,timeseries_tmp = ODE.ode23s(f,u0,Ts,
+                          norm = norm,
+                          abstol=abstol,
+                          reltol=reltol,
+                          maxstep=dtmax,
+                          minstep=dtmin,
+                          initstep=dt,
+                          points=points)
+    elseif typeof(alg) <: ode4
+        ts,timeseries_tmp = ODE.ode4(f,u0,Ts,
+                          norm = norm,
+                          abstol=abstol,
+                          reltol=reltol,
+                          maxstep=dtmax,
+                          minstep=dtmin,
+                          initstep=dt,
+                          points=points)
+    elseif typeof(alg) <: ode4ms
+        ts,timeseries_tmp = ODE.ode4ms(f,u0,Ts,
+                          norm = norm,
+                          abstol=abstol,
+                          reltol=reltol,
+                          maxstep=dtmax,
+                          minstep=dtmin,
+                          initstep=dt,
+                          points=points)
+    elseif typeof(alg) <: ode4s
+        ts,timeseries_tmp = ODE.ode4s(f,u0,Ts,
                           norm = norm,
                           abstol=abstol,
                           reltol=reltol,

--- a/src/common.jl
+++ b/src/common.jl
@@ -60,5 +60,3 @@ function solve{uType,tType,isinplace,AlgType<:ODEJLAlgorithm,F}(prob::AbstractOD
     build_solution(prob,alg,ts,timeseries,
                  timeseries_errors = timeseries_errors)
 end
-
-export ODEJLAlgorithm, ode23Alg, ode23sAlg, ode45Alg, ode78Alg

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,99 @@
+abstract ODEJLAlgorithm <: AbstractODEAlgorithm
+immutable ode23Alg <: ODEJLAlgorithm end
+immutable ode45Alg <: ODEJLAlgorithm end
+immutable ode23sAlg <: ODEJLAlgorithm end
+immutable ode78Alg <: ODEJLAlgorithm end
+
+function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractODEProblem{uType,tType,isinplace,F},
+    alg::algType,timeseries=[],ts=[],ks=[];dense=true,save_timeseries=true,
+    saveat=tType[],timeseries_errors=true,reltol = 1e-5, abstol = 1e-8,
+    dtmin = abs(prob.tspan[2]-prob.tspan[1])/1e-9,
+    dtmax = abs(prob.tspan[2]-prob.tspan[1])/2.5,
+    dt = 0.,norm = Base.vecnorm,
+    kwargs...)
+
+    tspan = prob.tspan
+
+    if tspan[end]-tspan[1]<tType(0)
+        error("final time must be greater than starting time. Aborting.")
+    end
+
+    u0 = prob.u0
+
+    Ts = sort(unique([tspan[1];saveat;tspan[2]]))
+
+    if save_timeseries
+        points = :all
+    else
+        points = :specified
+    end
+
+    sizeu = size(prob.u0)
+
+    if isinplace
+        f = (t,u) -> (du = zeros(u); prob.f(t,u,du); vec(du))
+    elseif uType <: AbstractArray
+        f = (t,u) -> vec(prob.f(t,reshape(u,sizeu)))
+    else
+        f = prob.f
+    end
+
+    if uType <: AbstractArray
+        u0 = vec(prob.u0)
+    else
+        u0 = prob.u0
+    end
+
+    if typeof(alg) <: ode23Alg
+        ts,timeseries_tmp = ODE.ode23(f,u0,Ts,
+                          norm = norm,
+                          abstol=abstol,
+                          reltol=reltol,
+                          maxstep=dtmax,
+                          minstep=dtmin,
+                          initstep=dt,
+                          points=points)
+    elseif typeof(alg) <: ode45Alg
+        ts,timeseries_tmp = ODE.ode45(f,u0,Ts,
+                          norm = norm,
+                          abstol=abstol,
+                          reltol=reltol,
+                          maxstep=dtmax,
+                          minstep=dtmin,
+                          initstep=dt,
+                          points=points)
+    elseif typeof(alg) <: ode78Alg
+        ts,timeseries_tmp = ODE.ode78(f,u0,Ts,
+                          norm = norm,
+                          abstol=abstol,
+                          reltol=reltol,
+                          maxstep=dtmax,
+                          minstep=dtmin,
+                          initstep=dt,
+                          points=points)
+    elseif typeof(alg) <: ode23sAlg
+        ts,timeseries_tmp = ODE.ode23s(f,u0,Ts,
+                          norm = norm,
+                          abstol=abstol,
+                          reltol=reltol,
+                          maxstep=dtmax,
+                          minstep=dtmin,
+                          initstep=dt,
+                          points=points)
+    end
+
+    # Reshape the result if needed
+    if uType <: AbstractArray
+        timeseries = Vector{uType}(0)
+        for i=1:length(timeseries_tmp)
+            push!(timeseries,reshape(timeseries_tmp[i],sizeu))
+        end
+    else
+        timeseries = timeseries_tmp
+    end
+
+    build_solution(prob,alg,ts,timeseries,
+                 timeseries_errors = timeseries_errors)
+end
+
+export ODEJLAlgorithm, ode23Alg, ode23sAlg, ode45Alg, ode78Alg

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,4 +1,4 @@
-function solve{uType,tType,isinplace,AlgType<:ODEJLAlgorithm,F}(prob::AbstractODEProblem{uType,tType,isinplace,F},
+function solve{uType,tType,isinplace,AlgType<:ODEjlAlgorithm,F}(prob::AbstractODEProblem{uType,tType,isinplace,F},
     alg::AlgType,timeseries=[],ts=[],ks=[];dense=true,save_timeseries=true,
     saveat=tType[],timeseries_errors=true,reltol = 1e-5, abstol = 1e-8,
     dtmin = abs(prob.tspan[2]-prob.tspan[1])/1e-9,
@@ -8,13 +8,9 @@ function solve{uType,tType,isinplace,AlgType<:ODEJLAlgorithm,F}(prob::AbstractOD
 
     tspan = prob.tspan
 
-    if tspan[end]-tspan[1]<tType(0)
-        error("final time must be greater than starting time. Aborting.")
-    end
-
     u0 = prob.u0
 
-    Ts = sort(unique([tspan[1];saveat;tspan[2]]))
+    Ts = unique([tspan[1];saveat;tspan[2]])
 
     if save_timeseries
         points = :all
@@ -32,12 +28,10 @@ function solve{uType,tType,isinplace,AlgType<:ODEJLAlgorithm,F}(prob::AbstractOD
         f = prob.f
     end
 
-    if uType <: AbstractArray
-        u0 = vec(prob.u0)
-    else
-        u0 = prob.u0
-    end
+    u0 = uType <: AbstractArray ? vec(prob.u0) : prob.u0
 
+    # Calling the solver, i.e. if the algorithm is ode45,
+    # then AlgType(...) is ode45(...)
     ts,timeseries_tmp = AlgType(f,u0,Ts;
                       norm = norm,
                       abstol=abstol,

--- a/src/common.jl
+++ b/src/common.jl
@@ -46,15 +46,6 @@ function solve{uType,tType,isinplace,AlgType<:ODEJLAlgorithm,F}(prob::AbstractOD
                       minstep=dtmin,
                       initstep=dt,
                       points=points)
-                      #=
-    elseif typeof(alg) <: ode4
-        ts,timeseries_tmp = ODE.ode4(f,u0,Ts)
-    elseif typeof(alg) <: ode4ms
-        ts,timeseries_tmp = ODE.ode4ms(f,u0,Ts)
-    elseif typeof(alg) <: ode4s
-        ts,timeseries_tmp = ODE.ode4s(f,u0,Ts)
-    end
-    =#
 
     # Reshape the result if needed
     if uType <: AbstractArray

--- a/src/common.jl
+++ b/src/common.jl
@@ -75,32 +75,11 @@ function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractOD
                           initstep=dt,
                           points=points)
     elseif typeof(alg) <: ode4
-        ts,timeseries_tmp = ODE.ode4(f,u0,Ts,
-                          norm = norm,
-                          abstol=abstol,
-                          reltol=reltol,
-                          maxstep=dtmax,
-                          minstep=dtmin,
-                          initstep=dt,
-                          points=points)
+        ts,timeseries_tmp = ODE.ode4(f,u0,Ts)
     elseif typeof(alg) <: ode4ms
-        ts,timeseries_tmp = ODE.ode4ms(f,u0,Ts,
-                          norm = norm,
-                          abstol=abstol,
-                          reltol=reltol,
-                          maxstep=dtmax,
-                          minstep=dtmin,
-                          initstep=dt,
-                          points=points)
+        ts,timeseries_tmp = ODE.ode4ms(f,u0,Ts)
     elseif typeof(alg) <: ode4s
-        ts,timeseries_tmp = ODE.ode4s(f,u0,Ts,
-                          norm = norm,
-                          abstol=abstol,
-                          reltol=reltol,
-                          maxstep=dtmax,
-                          minstep=dtmin,
-                          initstep=dt,
-                          points=points)
+        ts,timeseries_tmp = ODE.ode4s(f,u0,Ts)
     end
 
     # Reshape the result if needed

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,5 +1,5 @@
-function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractODEProblem{uType,tType,isinplace,F},
-    alg::algType,timeseries=[],ts=[],ks=[];dense=true,save_timeseries=true,
+function solve{uType,tType,isinplace,AlgType<:ODEJLAlgorithm,F}(prob::AbstractODEProblem{uType,tType,isinplace,F},
+    alg::AlgType,timeseries=[],ts=[],ks=[];dense=true,save_timeseries=true,
     saveat=tType[],timeseries_errors=true,reltol = 1e-5, abstol = 1e-8,
     dtmin = abs(prob.tspan[2]-prob.tspan[1])/1e-9,
     dtmax = abs(prob.tspan[2]-prob.tspan[1])/2.5,
@@ -38,42 +38,15 @@ function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractOD
         u0 = prob.u0
     end
 
-    if typeof(alg) <: ode23
-        ts,timeseries_tmp = ODE.ode23(f,u0,Ts,
-                          norm = norm,
-                          abstol=abstol,
-                          reltol=reltol,
-                          maxstep=dtmax,
-                          minstep=dtmin,
-                          initstep=dt,
-                          points=points)
-    elseif typeof(alg) <: ode45
-        ts,timeseries_tmp = ODE.ode45(f,u0,Ts,
-                          norm = norm,
-                          abstol=abstol,
-                          reltol=reltol,
-                          maxstep=dtmax,
-                          minstep=dtmin,
-                          initstep=dt,
-                          points=points)
-    elseif typeof(alg) <: ode78
-        ts,timeseries_tmp = ODE.ode78(f,u0,Ts,
-                          norm = norm,
-                          abstol=abstol,
-                          reltol=reltol,
-                          maxstep=dtmax,
-                          minstep=dtmin,
-                          initstep=dt,
-                          points=points)
-    elseif typeof(alg) <: ode23s
-        ts,timeseries_tmp = ODE.ode23s(f,u0,Ts,
-                          norm = norm,
-                          abstol=abstol,
-                          reltol=reltol,
-                          maxstep=dtmax,
-                          minstep=dtmin,
-                          initstep=dt,
-                          points=points)
+    ts,timeseries_tmp = AlgType(f,u0,Ts;
+                      norm = norm,
+                      abstol=abstol,
+                      reltol=reltol,
+                      maxstep=dtmax,
+                      minstep=dtmin,
+                      initstep=dt,
+                      points=points)
+                      #=
     elseif typeof(alg) <: ode4
         ts,timeseries_tmp = ODE.ode4(f,u0,Ts)
     elseif typeof(alg) <: ode4ms
@@ -81,6 +54,7 @@ function solve{uType,tType,isinplace,algType<:ODEJLAlgorithm,F}(prob::AbstractOD
     elseif typeof(alg) <: ode4s
         ts,timeseries_tmp = ODE.ode4s(f,u0,Ts)
     end
+    =#
 
     # Reshape the result if needed
     if uType <: AbstractArray

--- a/src/runge_kutta.jl
+++ b/src/runge_kutta.jl
@@ -165,9 +165,9 @@ const bt_feh78 = TableauRKExplicit(:feh78, (7,8), Rational{Int64},
 ode1(fn, y0, tspan) = oderk_fixed(fn, y0, tspan, bt_feuler)
 ode2_midpoint(fn, y0, tspan) = oderk_fixed(fn, y0, tspan, bt_midpoint)
 ode2_heun(fn, y0, tspan) = oderk_fixed(fn, y0, tspan, bt_heun)
-ode4(fn, y0, tspan) = oderk_fixed(fn, y0, tspan, bt_rk4)
+ode4(fn, y0, tspan;kwargs...) = oderk_fixed(fn, y0, tspan, bt_rk4;kwargs...)
 
-function oderk_fixed(fn, y0, tspan, btab::TableauRKExplicit)
+function oderk_fixed(fn, y0, tspan, btab::TableauRKExplicit;kwargs...)
     # Non-arrays y0 treat as scalar
     fn_(t, y) = [fn(t, y[1])]
     t,y = oderk_fixed(fn_, [y0], tspan, btab)

--- a/src/runge_kutta.jl
+++ b/src/runge_kutta.jl
@@ -216,7 +216,7 @@ ode23(fn, y0, tspan; kwargs...) = oderk_adapt(fn, y0, tspan, bt_rk23; kwargs...)
 ode45_fe(fn, y0, tspan; kwargs...) = oderk_adapt(fn, y0, tspan, bt_rk45; kwargs...)
 ode45_dp(fn, y0, tspan; kwargs...) = oderk_adapt(fn, y0, tspan, bt_dopri5; kwargs...)
 # Use Dormand-Prince version of ode45 by default
-const ode45 = ode45_dp
+ode45(fn, y0, tspan; kwargs...) = ode45_dp(fn, y0, tspan; kwargs...)
 ode78(fn, y0, tspan; kwargs...) = oderk_adapt(fn, y0, tspan, bt_feh78; kwargs...)
 
 function oderk_adapt(fn, y0, tspan, btab::TableauRKExplicit; kwords...)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+DiffEqProblemLibrary

--- a/test/common.jl
+++ b/test/common.jl
@@ -4,18 +4,18 @@ dt=1/2^(4)
 
 prob = prob_ode_linear
 
-sol =solve(prob,ODE.ode23Alg();dt=dt)
+sol =solve(prob,ODE.ode23();dt=dt)
 # plot(sol,plot_analytic=true)
 
-sol =solve(prob,ode23sAlg();dt=dt)
-sol =solve(prob,ode45Alg();dt=dt)
-sol =solve(prob,ode78Alg();dt=dt)
+sol =solve(prob,ode23s();dt=dt)
+sol =solve(prob,ode45();dt=dt)
+sol =solve(prob,ode78();dt=dt)
 
 prob = prob_ode_2Dlinear
 
-sol =solve(prob,ode23Alg();dt=dt,dtmin=eps())
+sol =solve(prob,ode23();dt=dt,dtmin=eps())
 # plot(sol,plot_analytic=true)
 
-sol =solve(prob,ode23sAlg();dt=dt)
-sol =solve(prob,ode45Alg();dt=dt)
-sol =solve(prob,ode78Alg();dt=dt)
+sol =solve(prob,ode23s();dt=dt)
+sol =solve(prob,ode45();dt=dt)
+sol =solve(prob,ode78();dt=dt)

--- a/test/common.jl
+++ b/test/common.jl
@@ -11,6 +11,10 @@ sol =solve(prob,ode23s();dt=dt)
 sol =solve(prob,ode45();dt=dt)
 sol =solve(prob,ode78();dt=dt)
 
+sol =solve(prob,ode4();dt=dt)
+sol =solve(prob,ode4ms();dt=dt)
+sol =solve(prob,ode4s();dt=dt)
+
 prob = prob_ode_2Dlinear
 
 sol =solve(prob,ode23();dt=dt,dtmin=eps())
@@ -19,3 +23,7 @@ sol =solve(prob,ode23();dt=dt,dtmin=eps())
 sol =solve(prob,ode23s();dt=dt)
 sol =solve(prob,ode45();dt=dt)
 sol =solve(prob,ode78();dt=dt)
+
+sol =solve(prob,ode4();dt=dt)
+sol =solve(prob,ode4ms();dt=dt)
+sol =solve(prob,ode4s();dt=dt)

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,0 +1,21 @@
+using ODE, DiffEqBase, DiffEqProblemLibrary
+
+dt=1/2^(4)
+
+prob = prob_ode_linear
+
+sol =solve(prob,ODE.ode23Alg();dt=dt)
+# plot(sol,plot_analytic=true)
+
+sol =solve(prob,ode23sAlg();dt=dt)
+sol =solve(prob,ode45Alg();dt=dt)
+sol =solve(prob,ode78Alg();dt=dt)
+
+prob = prob_ode_2Dlinear
+
+sol =solve(prob,ode23Alg();dt=dt,dtmin=eps())
+# plot(sol,plot_analytic=true)
+
+sol =solve(prob,ode23sAlg();dt=dt)
+sol =solve(prob,ode45Alg();dt=dt)
+sol =solve(prob,ode78Alg();dt=dt)

--- a/test/common.jl
+++ b/test/common.jl
@@ -2,28 +2,20 @@ using ODE, DiffEqBase, DiffEqProblemLibrary
 
 dt=1/2^(4)
 
+algs = [ode23(),ode45(),ode78(),ode4(),ode4ms(),ode4s()] # no ode23s
+
+# Check for errors
+
 prob = prob_ode_linear
 
-sol =solve(prob,ODE.ode23();dt=dt)
-# plot(sol,plot_analytic=true)
-
-sol =solve(prob,ode23s();dt=dt)
-sol =solve(prob,ode45();dt=dt)
-sol =solve(prob,ode78();dt=dt)
-
-sol =solve(prob,ode4();dt=dt)
-sol =solve(prob,ode4ms();dt=dt)
-sol =solve(prob,ode4s();dt=dt)
+for alg in algs
+  sol =solve(prob,alg;dt=dt,abstol=1e-6,reltol=1e-3)
+  @test typeof(sol[2]) <: Number
+end
 
 prob = prob_ode_2Dlinear
 
-sol =solve(prob,ode23();dt=dt,dtmin=eps())
-# plot(sol,plot_analytic=true)
-
-sol =solve(prob,ode23s();dt=dt)
-sol =solve(prob,ode45();dt=dt)
-sol =solve(prob,ode78();dt=dt)
-
-sol =solve(prob,ode4();dt=dt)
-sol =solve(prob,ode4ms();dt=dt)
-sol =solve(prob,ode4s();dt=dt)
+for alg in algs
+  sol =solve(prob,alg;dt=dt,dtmin=eps(),abstol=1e-6,reltol=1e-3)
+  @test size(sol[2]) == (4,2)
+end

--- a/test/common.jl
+++ b/test/common.jl
@@ -9,13 +9,13 @@ algs = [ode23(),ode45(),ode78(),ode4(),ode4ms(),ode4s()] # no ode23s
 prob = prob_ode_linear
 
 for alg in algs
-  sol =solve(prob,alg;dt=dt,abstol=1e-6,reltol=1e-3)
-  @test typeof(sol[2]) <: Number
+    sol =solve(prob,alg;dt=dt,abstol=1e-6,reltol=1e-3)
+    @test typeof(sol[2]) <: Number
 end
 
 prob = prob_ode_2Dlinear
 
 for alg in algs
-  sol =solve(prob,alg;dt=dt,dtmin=eps(),abstol=1e-6,reltol=1e-3)
-  @test size(sol[2]) == (4,2)
+    sol =solve(prob,alg;dt=dt,dtmin=eps(),abstol=1e-6,reltol=1e-3)
+    @test size(sol[2]) == (4,2)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,5 +103,5 @@ let
     @test norm(refsol-y[end], Inf) < 2e-10
 end
 include("interface-tests.jl")
-
+include("common.jl")
 println("All looks OK")


### PR DESCRIPTION
This adds common interface bindings to ODE.jl. Currently it only includes the algorithms in the README:

- ode23Alg
- ode45Alg
- ode78Alg
- ode23sAlg

I had to put the `Alg` in the type name because otherwise it matches the function's name. If anyone has a better idea of how to handle this let me know.