### PR TITLE
Update common interface

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
 Polynomials
 Compat 0.9
-DiffEqBase
+DiffEqBase 0.15.0

--- a/src/common.jl
+++ b/src/common.jl
@@ -3,6 +3,7 @@ function solve{uType,tType,isinplace,AlgType<:ODEjlAlgorithm}(prob::AbstractODEP
     save_timeseries=nothing,
     saveat=tType[],reltol = 1e-5, abstol = 1e-8,
     save_everystep=isempty(saveat),
+    save_start = true,
     dtmin = abs(prob.tspan[2]-prob.tspan[1])/1e-9,
     dtmax = abs(prob.tspan[2]-prob.tspan[1])/2.5,
     timeseries_errors=true,dense_errors=false,
@@ -64,10 +65,18 @@ function solve{uType,tType,isinplace,AlgType<:ODEjlAlgorithm}(prob::AbstractODEP
                       initstep=dt,
                       points=points)
 
-    # Reshape the result if needed
+
+    if save_start
+      start_idx = 1
+    else
+      start_idx = 2
+      ts = ts[2:end]
+    end
+
+    # Reshape the result if needed    
     if uType <: AbstractArray
         timeseries = Vector{uType}(0)
-        for i=1:length(timeseries_tmp)
+        for i=start_idx:length(timeseries_tmp)
             push!(timeseries,reshape(timeseries_tmp[i],sizeu))
         end
     else

--- a/src/common.jl
+++ b/src/common.jl
@@ -67,7 +67,7 @@ function solve{uType,tType,isinplace,AlgType<:ODEjlAlgorithm}(prob::AbstractODEP
 
 
     if save_start
-      start_idx = 1
+      start_idx = 1 # The index to start making the timeseries from
     else
       start_idx = 2
       ts = ts[2:end]


### PR DESCRIPTION
This updates the common interface to the new specs for DiffEqBase.jl's v0.15.0. It is incompatible with previous versions. This should not be merged until DiffEqBase.jl v0.15.0 is released, and upper bounds are placed in METADATA.