### PR TITLE
Add error for mass matrices

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -14,6 +14,10 @@ function solve{uType,tType,isinplace,AlgType<:ODEjlAlgorithm}(prob::AbstractODEP
         warn("save_timeseries is deprecated. Use save_everystep instead")
         save_everystep = save_timeseries
     end
+    
+    if prob.mass_matrix != I
+        error("This solver is not able to use mass matrices.")
+    end
 
     tspan = prob.tspan
 


### PR DESCRIPTION
They are not supported, so it would be good to notify the user that this cannot solve the requested problem. This will require the next DiffEqBase tag.