### PR TITLE
fix depwarns on v0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
 Polynomials
-Compat 0.9
+Compat 0.17.0
 DiffEqBase 1.0.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,10 @@ environment:
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
-
+matrix:
+  allow_failures:
+    - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+    - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 branches:
   only:
     - master

--- a/src/ODE.jl
+++ b/src/ODE.jl
@@ -33,7 +33,7 @@ export ODEjlAlgorithm
 # Butcher Tableaus, or more generally coefficient tables
 # see Hairer & Wanner 1992, p. 134, 166
 
-abstract Tableau{Name, S, T<:Real}
+@compat abstract type Tableau{Name, S, T<:Real} end
 # Name is the name of the tableau/method (a symbol)
 # S is the number of stages (an int)
 # T is the type of the coefficients

--- a/src/algorithm_types.jl
+++ b/src/algorithm_types.jl
@@ -1,4 +1,4 @@
-abstract ODEjlAlgorithm <: AbstractODEAlgorithm
+@compat abstract type ODEjlAlgorithm <: AbstractODEAlgorithm end
 # Making the ODE-solver functions into types lets us dispatch on them.
 #  Used in the DiffEqBase interface.
 immutable ode23 <: ODEjlAlgorithm end

--- a/src/runge_kutta.jl
+++ b/src/runge_kutta.jl
@@ -13,7 +13,7 @@ immutable TableauRKExplicit{Name, S, T} <: Tableau{Name, S, T}
     # second for error calc.
     b::Matrix{T}
     c::Vector{T}
-    function TableauRKExplicit(order,a,b,c)
+    function (::Type{TableauRKExplicit{Name, S, T}}){Name, S, T}(order,a,b,c)
         @assert isa(S,Integer)
         @assert isa(Name,Symbol)
         @assert c[1]==0
@@ -26,7 +26,7 @@ immutable TableauRKExplicit{Name, S, T} <: Tableau{Name, S, T}
         else
             @assert norm(sum(a,2)-c'',Inf) < 100*eps(Float64)
         end
-        new(order,a,b,c)
+        new{Name, S, T}(order,a,b,c)
     end
 end
 function TableauRKExplicit{T}(name::Symbol, order::(@compat(Tuple{Vararg{Int}})),


### PR DESCRIPTION
ODE.jl still won't compile on v0.6 (that looks like it may take a lot of work, and I don't have the time for it right now), but I at least fixed all of the depwarns it causes.